### PR TITLE
Prevent search results from being crawled

### DIFF
--- a/ckan/public/robots.txt
+++ b/ckan/public/robots.txt
@@ -2,6 +2,10 @@ User-agent: *
 Disallow: /dataset/rate/
 Disallow: /revision/
 Disallow: /dataset/*/history
+Disallow: /dataset?
+Disallow: /organization?
+Disallow: /harvest?
+Disallow: /group?
 Disallow: /api/
 Sitemap: https://filestore.data.gov/gsa/catalog/sitemap/sitemap.xml
 Crawl-delay: 10


### PR DESCRIPTION
For some background on why not to include local search result pages in external search engine search results see https://www.mattcutts.com/blog/search-results-in-search-results/