### PR TITLE
[inventory] Use filter query for search within organization

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -235,11 +235,6 @@ class GroupController(base.BaseController):
                    'for_view': True, 'extras_as_string': True}
 
         q = c.q = request.params.get('q', '')
-        # Search within group
-        if c.group_dict.get('is_organization'):
-            q += ' owner_org:"%s"' % c.group_dict.get('id')
-        else:
-            q += ' groups:"%s"' % c.group_dict.get('name')
 
         c.description_formatted = \
             h.render_markdown(c.group_dict.get('description'))
@@ -297,13 +292,24 @@ class GroupController(base.BaseController):
                     else:
                         search_extras[param] = value
 
-            fq = 'capacity:"public"'
+            # Search within group
             user_member_of_orgs = [org['id'] for org
                                    in h.organizations_available('read')]
 
             if (c.group and c.group.id in user_member_of_orgs):
                 fq = ''
                 context['ignore_capacity_check'] = True
+            else:
+                fq = 'capacity:"public"'
+
+            # Data.gov https://github.com/GSA/datagov-deploy/issues/851
+            # Use fq=organization:xxx instead of q=owner_org:xxx to reduce the
+            # inconsistencies in querying on home page vs organization page.
+            if c.group_dict.get('is_organization'):
+                fq += ' owner_org:"%s"' % c.group_dict.get('id')
+            else:
+                fq += ' groups:"%s"' % c.group_dict.get('name')
+
 
             facets = OrderedDict()
 


### PR DESCRIPTION
The dataset search on the homepage uses a DisMax query, while the dataset search
on the organization does not. This produces wildly inconsistent results. In some
cases, no results appear when using search from the organization page. Using
a filter query for the organization produces better results. A true fix would be
making these queries the same (both DisMax or neither DisMax) and tuning search.