### PR TITLE
Inventory fix

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ bleach==1.4.2
 Genshi==0.6
 WebTest==1.4.3  # need to pin this so that Pylons does not install a newer version that conflicts with WebOb==1.0.8
 fanstatic==0.12
+M2Crypto==0.23.0
 Markdown==2.4
 ofs==0.4.1
 ordereddict==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ formencode==1.3.0         # via pylons
 Genshi==0.6
 html5lib==0.9999999
 Jinja2==2.6
+M2Crypto==0.23.0
 mako==1.0.2               # via pylons
 Markdown==2.4
 markupsafe==0.23          # via mako, webhelpers


### PR DESCRIPTION
We're seeing an error importing M2Crypto.

```
[Tue Oct 08 19:26:07.888325 2019] [:error] [pid 22953:tid 139628758513408] [remote 127.0.0.1:30947] ImportError: No module named M2Crypto
```

I had removed it in https://github.com/GSA/datagov-deploy/commit/31876316384df745453e98ae142ff981c0a7eb2b and moved it to requirements.txt, but only for bionic. I forgot that we still need it for trusty. This just adds it to requirements.txt where it should live anyway.