### PR TITLE
Revert #63 manual update to requirements.txt

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,6 @@ bleach==1.4.2
 Genshi==0.6
 WebTest==1.4.3  # need to pin this so that Pylons does not install a newer version that conflicts with WebOb==1.0.8
 fanstatic==0.12
-M2Crypto==0.23.0
 Markdown==2.4
 ofs==0.4.1
 ordereddict==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ formencode==1.3.0         # via pylons
 Genshi==0.6
 html5lib==0.9999999
 Jinja2==2.6
-M2Crypto==0.23.0
 mako==1.0.2               # via pylons
 Markdown==2.4
 markupsafe==0.23          # via mako, webhelpers


### PR DESCRIPTION
This reverts commit 37eb8c3c0c1484c51b88d1cd379250fddce2f3f6, reversing
changes made to 2c4c11b1a6efa270ce8c8bb2475228170797d7e7.

Remove the manual edit to requirements.txt. Seeing issues with more-itertools[1].

Having a development environment for Inventory would be nice.

[1]: https://github.com/GSA/datagov-deploy/issues/1042