### PR TITLE
pull in group_type instead of declaring

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -245,7 +245,7 @@ class GroupController(base.BaseController):
 
         def remove_field(key, value=None, replace=None):
             return h.remove_url_param(key, value=value, replace=replace,
-                                      controller='group', action='read',
+                                      controller=self.group_type, action='read',
                                       extras=dict(id=c.group_dict.get('name')))
 
         c.remove_field = remove_field


### PR DESCRIPTION
Part of [this ticket](https://github.com/GSA/datagov-deploy/issues/1972)

Startes with [search_form.html](https://github.com/GSA/ckan/blob/datagov/ckan/templates/snippets/search_form.html#L65) which calls the remove_field function. Currently sets sets the [controller parameter](https://github.com/GSA/ckan/blob/datagov/ckan/controllers/group.py#L248) explicitly. 

This will pull it from group_type [in the same script](https://github.com/GSA/ckan/blob/datagov/ckan/controllers/group.py#L42) or from the [organization script](https://github.com/GSA/ckan/blob/datagov/ckan/controllers/organization.py#L16).