### PR TITLE
Add a default value for non-serializable fields

### DIFF
--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -83,7 +83,7 @@ class ApiController(base.BaseController):
         if response_data is not None:
             response.headers['Content-Type'] = CONTENT_TYPES[content_type]
             if content_type == 'json':
-                response_msg = h.json.dumps(response_data)
+                response_msg = h.json.dumps(response_data, default=lambda o: "<<non-serializable: {}>>".format(type(o)))
             else:
                 response_msg = response_data
             # Support "JSONP" callback.


### PR DESCRIPTION
Related to [Multi#486](https://github.com/GSA/datagov-ckan-multi/issues/486)

This PR adds a default function to deal with non-serializable fields before parse JSON data.
It will be better to fix the specific field in the harvest source but we don't know which field is failing.

CKAN upstream already make [some changes here](https://github.com/GSA/ckan/commit/3462450d5deb018d5c67d47b7872cfee075f19ee)