### PR TITLE
make version easy to be detected

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ for group, filepath in _extras_groups:
         extras_require[group] = f.readlines()
 
 setup(
+    name="ckan",
+    version="2.11.2",
+    description="datagov fork of CKAN",
     message_extractors={
         "ckan": [
             ("**.py", "python", None),


### PR DESCRIPTION
snyk dashboard assumes our `ckan-2.11-2-fork` is on ckan version 2.3. added explicit version into `setup.py` so that version `2.11.2` is picked by snyk dashboard.

<img width="486" height="250" alt="image" src="https://github.com/user-attachments/assets/3e435f12-e770-45e1-8f6e-a183ce990f5f" />


Thoughts:

Another approach we could use is to tag the last commit with ckan-2.11.2. But it feels weird to have a tag with changing commit numbers.